### PR TITLE
More python versions

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -10,6 +10,14 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
+      linux_python2.7target_platformlinux-64:
+        CONFIG: linux_python2.7target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_python3.6target_platformlinux-64:
+        CONFIG: linux_python3.6target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
       linux_python3.7target_platformlinux-64:
         CONFIG: linux_python3.7target_platformlinux-64
         UPLOAD_PACKAGES: True

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -10,6 +10,12 @@ jobs:
   strategy:
     maxParallel: 8
     matrix:
+      osx_python2.7target_platformosx-64:
+        CONFIG: osx_python2.7target_platformosx-64
+        UPLOAD_PACKAGES: True
+      osx_python3.6target_platformosx-64:
+        CONFIG: osx_python3.6target_platformosx-64
+        UPLOAD_PACKAGES: True
       osx_python3.7target_platformosx-64:
         CONFIG: osx_python3.7target_platformosx-64
         UPLOAD_PACKAGES: True

--- a/.ci_support/linux_python2.7target_platformlinux-64.yaml
+++ b/.ci_support/linux_python2.7target_platformlinux-64.yaml
@@ -1,0 +1,36 @@
+boost:
+- 1.70.0
+boost_cpp:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+expat:
+- '2.2'
+gmp:
+- '6'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+target_platform:
+- linux-64

--- a/.ci_support/linux_python3.6target_platformlinux-64.yaml
+++ b/.ci_support/linux_python3.6target_platformlinux-64.yaml
@@ -1,0 +1,36 @@
+boost:
+- 1.70.0
+boost_cpp:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+expat:
+- '2.2'
+gmp:
+- '6'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+target_platform:
+- linux-64

--- a/.ci_support/osx_python2.7target_platformosx-64.yaml
+++ b/.ci_support/osx_python2.7target_platformosx-64.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost:
+- 1.70.0
+boost_cpp:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+expat:
+- '2.2'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+target_platform:
+- osx-64

--- a/.ci_support/osx_python3.6target_platformosx-64.yaml
+++ b/.ci_support/osx_python3.6target_platformosx-64.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost:
+- 1.70.0
+boost_cpp:
+- 1.70.0
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+expat:
+- '2.2'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+target_platform:
+- osx-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @stuarteberg
+* @count0 @ostrokach @stuarteberg

--- a/README.md
+++ b/README.md
@@ -29,10 +29,38 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
+              <td>linux_python2.7target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=linux&configuration=linux_python2.7target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_python3.6target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=linux&configuration=linux_python3.6target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_python3.7target_platformlinux-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=linux&configuration=linux_python3.7target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python2.7target_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=osx&configuration=osx_python2.7target_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.6target_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=osx&configuration=osx_python3.6target_platformosx-64" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -149,5 +177,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@count0](https://github.com/count0/)
+* [@ostrokach](https://github.com/ostrokach/)
 * [@stuarteberg](https://github.com/stuarteberg/)
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,7 @@ export BOOST_ROOT="${PREFIX}"
 
 # Explicitly set this, which is used in configure.
 # (We patched away the auto-detection of this variable.)
-export BOOST_PYTHON_LIB=boost_python37
+export BOOST_PYTHON_LIB=boost_python${CONDA_PY}
 
 # Note about PYTHON_LIBS:
 # If left unset, the configure script will set PYTHON_LIBS as follows:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     - patches/no-max-element-graph-blockmodel.patch  # [osx]
 
 build:
-  skip: true  # [win or py != 37]
+  skip: true  # [win]
   number: 0
   detect_binary_files_with_prefix: true
 


### PR DESCRIPTION
Previously, we skipped all configurations other than python 3.7.  This PR changes that:

```diff
 build:
-  skip: true  # [win or py != 37]
+  skip: true  # [win]
```

Which means we'll be building for python 2.7, 3.6, and 3.7 (as specified in the [conda-forge pinnings][pinnings]).

[pinnings]: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/ccf535a8bf67d8947fc6ac0c5bf12b4389e457f3/recipe/conda_build_config.yaml#L548-L551

Closes #3

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* (n/a) Bumped the build number (if the version is unchanged)
* (n/a) Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` [I did it locally, before pushing.]
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
