### PR TITLE
Python 3.8 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,6 +22,10 @@ jobs:
         CONFIG: linux_python3.7target_platformlinux-64
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_python3.8target_platformlinux-64:
+        CONFIG: linux_python3.8target_platformlinux-64
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -19,6 +19,9 @@ jobs:
       osx_python3.7target_platformosx-64:
         CONFIG: osx_python3.7target_platformosx-64
         UPLOAD_PACKAGES: True
+      osx_python3.8target_platformosx-64:
+        CONFIG: osx_python3.8target_platformosx-64
+        UPLOAD_PACKAGES: True
 
   steps:
   # TODO: Fast finish on azure pipelines?

--- a/.ci_support/linux_python3.8target_platformlinux-64.yaml
+++ b/.ci_support/linux_python3.8target_platformlinux-64.yaml
@@ -1,0 +1,36 @@
+boost:
+- '1.72'
+boost_cpp:
+- '1.72'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+expat:
+- '2.2'
+gmp:
+- '6'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'
+target_platform:
+- linux-64

--- a/.ci_support/migrations/python38.yaml
+++ b/.ci_support/migrations/python38.yaml
@@ -1,0 +1,55 @@
+migrator_ts: 1569538102   # The timestamp of when the migration was made
+__migrator: 
+  kind: 
+    version
+  exclude:
+    - c_compiler
+    - vc
+    - cxx_compiler
+  migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
+    1 
+  bump_number: 0
+
+python:
+  - 2.7
+  - 3.6
+  - 3.7
+  - 3.8
+
+c_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_c                # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gcc                        # [linux64]
+  - clang                      # [osx]
+  # non-standard arches get built with gcc
+  - gcc                        # [aarch64]
+  - gcc                        # [ppc64le]
+  - gcc                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+cxx_compiler:
+  # legacy compilers for things that refuse to move
+  - toolchain_cxx              # [(linux64 or osx) and (environ.get('CF_COMPILER_STACK') == 'comp4')]
+  # modern compilers
+  - gxx                        # [linux64]
+  - clangxx                    # [osx]
+
+  - gxx                        # [aarch64]
+  - gxx                        # [ppc64le]
+  - gxx                        # [armv7l]
+
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+
+vc:                    # [win]
+  - 9                  # [win]
+  - 14                 # [win]
+  - 14                 # [win]
+  - 14                 # [win]

--- a/.ci_support/osx_python3.8target_platformosx-64.yaml
+++ b/.ci_support/osx_python3.8target_platformosx-64.yaml
@@ -1,0 +1,36 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+boost:
+- '1.72'
+boost_cpp:
+- '1.72'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+expat:
+- '2.2'
+gmp:
+- '6'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.14'
+pin_run_as_build:
+  boost:
+    max_pin: x.x.x
+  boost-cpp:
+    max_pin: x.x.x
+  expat:
+    max_pin: x.x
+  gmp:
+    max_pin: x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.8'
+target_platform:
+- osx-64

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_python3.8target_platformlinux-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=linux&configuration=linux_python3.8target_platformlinux-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_python2.7target_platformosx-64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
@@ -68,6 +75,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=osx&configuration=osx_python3.7target_platformosx-64" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_python3.8target_platformosx-64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=master&jobName=osx&configuration=osx_python3.8target_platformosx-64" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,16 @@ build:
   number: 1
   detect_binary_files_with_prefix: true
 
+  # conda-build 3.18.12 uses LIEF instead of patchelf,
+  # which may be causing problems for this recipe.
+  # We can force it to use patchelf with this setting.
+  # There might be other bugs related to LIEF, too:
+  # - https://github.com/conda-forge/staged-recipes/pull/10979#issuecomment-595388237
+  # - https://github.com/lief-project/LIEF/issues/239
+  # 
+  # (Maybe this setting won't be needed in a later version of conda-build.)
+  rpaths_patcher: patchelf  # [linux]
+
 requirements:
   build:
     - libtool


### PR DESCRIPTION
This is based on the latest master.  To create this PR, I cherry-picked the relevant commit from #7, and then re-rendered the recipe.  Unlike #7, this one should work because the recipe no longer incorrectly depends on the `cgal` python package.  It only depends on `cgal-cpp`.