### PR TITLE
Remove drawing dependencies from base package

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
   # conda-build 3.18.12 uses LIEF instead of patchelf,
@@ -36,6 +36,11 @@ build:
 outputs:
   - name: graph-tool-base
     script: build_base.sh
+    build:
+      ignore_run_exports_from:
+        - pycairo
+        - cairomm
+        - glib
     requirements:
       build:
         - make
@@ -71,8 +76,10 @@ outputs:
         - zstandard
     test:
       files:
+        - test_base_deps.sh
         - test_base_imports.py
       commands:
+        - bash test_base_deps.sh
         - python test_base_imports.py
 
   - name: graph-tool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set sha1 = "220e71bb4ae794d7f992b01b992f47fa396a4c4d" %}
 
 package:
-  name: graph-tool
+  name: graph-tool-suite
   version: {{ version }}
 
 source:

--- a/recipe/test_base_deps.sh
+++ b/recipe/test_base_deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if (conda list | grep cairo); then
+    1>&2 echo "graph-tool-base should not install cairo"
+    exit 1
+fi
+
+if (conda list | grep glib); then
+    1>&2 echo "graph-tool-base should not install glib"
+    exit 1
+fi


### PR DESCRIPTION
This is to properly remove drawing dependencies in `graph-tool-base`, so users have the option to install graph-tool without `gtk3`, `cairo`, etc.  Fixes #28, hopefully correctly this time.

This removes the dependencies which were implicitly added to the base package due to `run_exports` settings in those dependencies.

Assuming the build succeeds, I'll download the build artifacts and try installing them locally to verify that the packages don't install 

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy`.
    * (Rerender said no changes needed.)

