### PR TITLE
microarch updates for boost-1.82 branch

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,31 +8,81 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.22python3.10.____cpython:
-        CONFIG: linux_64_numpy1.22python3.10.____cpython
+      linux_64_microarch_level1numpy1.22python3.10.____cpython:
+        CONFIG: linux_64_microarch_level1numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.22python3.10.____cpython
-      linux_64_numpy1.22python3.8.____cpython:
-        CONFIG: linux_64_numpy1.22python3.8.____cpython
+        SHORT_CONFIG: linux_64_microarch_level1numpy1.22p_h6de6e95d03
+      linux_64_microarch_level1numpy1.22python3.8.____cpython:
+        CONFIG: linux_64_microarch_level1numpy1.22python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.22python3.8.____cpython
-      linux_64_numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_numpy1.22python3.9.____cpython
+        SHORT_CONFIG: linux_64_microarch_level1numpy1.22p_h54b34efe15
+      linux_64_microarch_level1numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_microarch_level1numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.22python3.9.____cpython
-      linux_64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: linux_64_microarch_level1numpy1.22p_h27ea7e1d00
+      linux_64_microarch_level1numpy1.23python3.11.____cpython:
+        CONFIG: linux_64_microarch_level1numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.23python3.11.____cpython
-      linux_64_numpy1.26python3.12.____cpython:
-        CONFIG: linux_64_numpy1.26python3.12.____cpython
+        SHORT_CONFIG: linux_64_microarch_level1numpy1.23p_hb39d452263
+      linux_64_microarch_level1numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_microarch_level1numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-        SHORT_CONFIG: linux_64_numpy1.26python3.12.____cpython
+        SHORT_CONFIG: linux_64_microarch_level1numpy1.26p_h795fb69a68
+      linux_64_microarch_level3numpy1.22python3.10.____cpython:
+        CONFIG: linux_64_microarch_level3numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level3numpy1.22p_h4ffc5dfc04
+      linux_64_microarch_level3numpy1.22python3.8.____cpython:
+        CONFIG: linux_64_microarch_level3numpy1.22python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level3numpy1.22p_h5562e6072c
+      linux_64_microarch_level3numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_microarch_level3numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level3numpy1.22p_h43a03df9f2
+      linux_64_microarch_level3numpy1.23python3.11.____cpython:
+        CONFIG: linux_64_microarch_level3numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level3numpy1.23p_h3d28bc93db
+      linux_64_microarch_level3numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_microarch_level3numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level3numpy1.26p_heab2ad146e
+      linux_64_microarch_level4numpy1.22python3.10.____cpython:
+        CONFIG: linux_64_microarch_level4numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level4numpy1.22p_hcf3a6d2248
+      linux_64_microarch_level4numpy1.22python3.8.____cpython:
+        CONFIG: linux_64_microarch_level4numpy1.22python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level4numpy1.22p_h26c0d0f042
+      linux_64_microarch_level4numpy1.22python3.9.____cpython:
+        CONFIG: linux_64_microarch_level4numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level4numpy1.22p_hcd0c319c95
+      linux_64_microarch_level4numpy1.23python3.11.____cpython:
+        CONFIG: linux_64_microarch_level4numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level4numpy1.23p_he83de3b09c
+      linux_64_microarch_level4numpy1.26python3.12.____cpython:
+        CONFIG: linux_64_microarch_level4numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        SHORT_CONFIG: linux_64_microarch_level4numpy1.26p_hce4cc769c4
       linux_aarch64_numpy1.22python3.10.____cpython:
         CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,26 +8,66 @@ jobs:
     vmImage: macOS-12
   strategy:
     matrix:
-      osx_64_numpy1.22python3.10.____cpython:
-        CONFIG: osx_64_numpy1.22python3.10.____cpython
+      osx_64_microarch_level1numpy1.22python3.10.____cpython:
+        CONFIG: osx_64_microarch_level1numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.22python3.10.____cpython
-      osx_64_numpy1.22python3.8.____cpython:
-        CONFIG: osx_64_numpy1.22python3.8.____cpython
+        SHORT_CONFIG: osx_64_microarch_level1numpy1.22pyt_h1dca26e0e9
+      osx_64_microarch_level1numpy1.22python3.8.____cpython:
+        CONFIG: osx_64_microarch_level1numpy1.22python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.22python3.8.____cpython
-      osx_64_numpy1.22python3.9.____cpython:
-        CONFIG: osx_64_numpy1.22python3.9.____cpython
+        SHORT_CONFIG: osx_64_microarch_level1numpy1.22pyt_h145249f9e5
+      osx_64_microarch_level1numpy1.22python3.9.____cpython:
+        CONFIG: osx_64_microarch_level1numpy1.22python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.22python3.9.____cpython
-      osx_64_numpy1.23python3.11.____cpython:
-        CONFIG: osx_64_numpy1.23python3.11.____cpython
+        SHORT_CONFIG: osx_64_microarch_level1numpy1.22pyt_h8d5304a799
+      osx_64_microarch_level1numpy1.23python3.11.____cpython:
+        CONFIG: osx_64_microarch_level1numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.23python3.11.____cpython
-      osx_64_numpy1.26python3.12.____cpython:
-        CONFIG: osx_64_numpy1.26python3.12.____cpython
+        SHORT_CONFIG: osx_64_microarch_level1numpy1.23pyt_haf05d50abc
+      osx_64_microarch_level1numpy1.26python3.12.____cpython:
+        CONFIG: osx_64_microarch_level1numpy1.26python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        SHORT_CONFIG: osx_64_numpy1.26python3.12.____cpython
+        SHORT_CONFIG: osx_64_microarch_level1numpy1.26pyt_h53581bb33a
+      osx_64_microarch_level3numpy1.22python3.10.____cpython:
+        CONFIG: osx_64_microarch_level3numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level3numpy1.22pyt_h62835ed6ac
+      osx_64_microarch_level3numpy1.22python3.8.____cpython:
+        CONFIG: osx_64_microarch_level3numpy1.22python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level3numpy1.22pyt_h9dc678df63
+      osx_64_microarch_level3numpy1.22python3.9.____cpython:
+        CONFIG: osx_64_microarch_level3numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level3numpy1.22pyt_h52148d253c
+      osx_64_microarch_level3numpy1.23python3.11.____cpython:
+        CONFIG: osx_64_microarch_level3numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level3numpy1.23pyt_hf0eb2a186b
+      osx_64_microarch_level3numpy1.26python3.12.____cpython:
+        CONFIG: osx_64_microarch_level3numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level3numpy1.26pyt_hd440d237f0
+      osx_64_microarch_level4numpy1.22python3.10.____cpython:
+        CONFIG: osx_64_microarch_level4numpy1.22python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level4numpy1.22pyt_hef6707ceec
+      osx_64_microarch_level4numpy1.22python3.8.____cpython:
+        CONFIG: osx_64_microarch_level4numpy1.22python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level4numpy1.22pyt_h4752e3aa51
+      osx_64_microarch_level4numpy1.22python3.9.____cpython:
+        CONFIG: osx_64_microarch_level4numpy1.22python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level4numpy1.22pyt_hf6d09a35de
+      osx_64_microarch_level4numpy1.23python3.11.____cpython:
+        CONFIG: osx_64_microarch_level4numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level4numpy1.23pyt_h250e800edc
+      osx_64_microarch_level4numpy1.26python3.12.____cpython:
+        CONFIG: osx_64_microarch_level4numpy1.26python3.12.____cpython
+        UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_microarch_level4numpy1.26pyt_hb0d1d71d35
       osx_arm64_numpy1.22python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.22python3.10.____cpython
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_microarch_level1numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1numpy1.22python3.10.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -35,9 +31,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level1numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1numpy1.22python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ glib:
 - '2'
 gmp:
 - '6'
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -29,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_microarch_level1numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1numpy1.22python3.9.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -37,7 +33,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level1numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1numpy1.23python3.11.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,15 +25,15 @@ gmp:
 microarch_level:
 - '1'
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level1numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level1numpy1.26python3.12.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -29,15 +25,15 @@ gmp:
 microarch_level:
 - '1'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.10.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '3'
 numpy:

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.10.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,8 +22,12 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.8.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '3'
 numpy:

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.8.____cpython.yaml
@@ -22,14 +22,20 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+microarch_level:
+- '3'
 numpy:
-- '1.26'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.9.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '3'
 numpy:

--- a/.ci_support/linux_64_microarch_level3numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.22python3.9.____cpython.yaml
@@ -1,19 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
 - '2'
 gdk_pixbuf:
@@ -22,10 +22,12 @@ glib:
 - '2'
 gmp:
 - '6'
-llvm_openmp:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+microarch_level:
+- '3'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -33,9 +35,11 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy

--- a/.ci_support/linux_64_microarch_level3numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.23python3.11.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '3'
 numpy:

--- a/.ci_support/linux_64_microarch_level3numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.23python3.11.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,18 +22,22 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '3'
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level3numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.26python3.12.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '3'
 numpy:

--- a/.ci_support/linux_64_microarch_level3numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level3numpy1.26python3.12.____cpython.yaml
@@ -1,19 +1,19 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '10.13'
+- '2.12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 expat:
 - '2'
 gdk_pixbuf:
@@ -22,20 +22,24 @@ glib:
 - '2'
 gmp:
 - '6'
-llvm_openmp:
-- '16'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+microarch_level:
+- '3'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_stdlib_version
+  - cdt_name
 - - python
   - numpy

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.10.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,8 +22,12 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.10.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '4'
 numpy:

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.8.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,8 +22,12 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,9 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.8.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '4'
 numpy:

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.9.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,8 +22,12 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -37,7 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level4numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.22python3.9.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '4'
 numpy:

--- a/.ci_support/linux_64_microarch_level4numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.23python3.11.____cpython.yaml
@@ -1,13 +1,9 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
+- '2.12'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
@@ -26,18 +22,22 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 microarch_level:
-- '1'
+- '4'
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_stdlib_version
   - cdt_name

--- a/.ci_support/linux_64_microarch_level4numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.23python3.11.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '4'
 numpy:

--- a/.ci_support/linux_64_microarch_level4numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.26python3.12.____cpython.yaml
@@ -22,14 +22,20 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+microarch_level:
+- '4'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_microarch_level4numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_microarch_level4numpy1.26python3.12.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 microarch_level:
 - '4'
 numpy:

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ glib:
 - '2'
 gmp:
 - '6'
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.8.____cpython.yaml
@@ -26,6 +26,8 @@ glib:
 - '2'
 gmp:
 - '6'
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ glib:
 - '2'
 gmp:
 - '6'
+microarch_level:
+- '1'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ glib:
 - '2'
 gmp:
 - '6'
+microarch_level:
+- '1'
 numpy:
 - '1.26'
 pin_run_as_build:

--- a/.ci_support/osx_64_microarch_level1numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1numpy1.22python3.10.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,6 +22,10 @@ glib:
 - '2'
 gmp:
 - '6'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
@@ -35,11 +35,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level1numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1numpy1.22python3.8.____cpython.yaml
@@ -26,14 +26,16 @@ llvm_openmp:
 - '16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+microarch_level:
+- '1'
 numpy:
-- '1.26'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.12.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_microarch_level1numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1numpy1.22python3.9.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,6 +22,10 @@ glib:
 - '2'
 gmp:
 - '6'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
@@ -37,9 +37,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level1numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1numpy1.23python3.11.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,20 +22,22 @@ glib:
 - '2'
 gmp:
 - '6'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level1numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level1numpy1.26python3.12.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,20 +22,22 @@ glib:
 - '2'
 gmp:
 - '6'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
 - '1'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.10.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.10.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,8 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,11 +39,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.8.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.8.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,8 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,11 +39,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.9.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level3numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.22python3.9.____cpython.yaml
@@ -22,10 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -33,7 +39,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_microarch_level3numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.23python3.11.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level3numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.23python3.11.____cpython.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.12'
-cdt_name:
-- cos6
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -22,6 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '3'
 numpy:
 - '1.23'
 pin_run_as_build:
@@ -31,9 +41,7 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level3numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.26python3.12.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,20 +22,26 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '3'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level3numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level3numpy1.26python3.12.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.10.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,8 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,11 +39,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.10.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.8.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,8 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -35,11 +39,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.8.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.9.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level4numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.22python3.9.____cpython.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.12'
-cdt_name:
-- cos6
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -22,6 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -29,11 +39,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level4numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.23python3.11.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_64_microarch_level4numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.23python3.11.____cpython.yaml
@@ -22,10 +22,16 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:
 - x86_64-apple-darwin13.4.0
+microarch_level:
+- '4'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/osx_64_microarch_level4numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.26python3.12.____cpython.yaml
@@ -1,23 +1,19 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '12'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '16'
 expat:
 - '2'
 gdk_pixbuf:
@@ -26,20 +22,26 @@ glib:
 - '2'
 gmp:
 - '6'
+libboost_devel:
+- '1.84'
+libboost_python_devel:
+- '1.84'
+llvm_openmp:
+- '16'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 microarch_level:
-- '1'
+- '4'
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
-- - c_stdlib_version
-  - cdt_name
 - - python
   - numpy

--- a/.ci_support/osx_64_microarch_level4numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_microarch_level4numpy1.26python3.12.____cpython.yaml
@@ -22,10 +22,6 @@ glib:
 - '2'
 gmp:
 - '6'
-libboost_devel:
-- '1.84'
-libboost_python_devel:
-- '1.84'
 llvm_openmp:
 - '16'
 macos_machine:

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -26,6 +26,8 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.8.____cpython.yaml
@@ -26,6 +26,8 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -26,6 +26,8 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '1.22'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -26,6 +26,8 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '1.23'
 pin_run_as_build:

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -26,6 +26,8 @@ llvm_openmp:
 - '16'
 macos_machine:
 - arm64-apple-darwin20.0.0
+microarch_level:
+- '1'
 numpy:
 - '1.26'
 pin_run_as_build:

--- a/README.md
+++ b/README.md
@@ -31,38 +31,108 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.22python3.10.____cpython</td>
+              <td>linux_64_microarch_level1numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1numpy1.22python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.8.____cpython</td>
+              <td>linux_64_microarch_level1numpy1.22python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1numpy1.22python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.9.____cpython</td>
+              <td>linux_64_microarch_level1numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.23python3.11.____cpython</td>
+              <td>linux_64_microarch_level1numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.26python3.12.____cpython</td>
+              <td>linux_64_microarch_level1numpy1.26python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level1numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3numpy1.22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3numpy1.22python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3numpy1.22python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level3numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level3numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level4numpy1.22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level4numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level4numpy1.22python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level4numpy1.22python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level4numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level4numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level4numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level4numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_microarch_level4numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_microarch_level4numpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -101,38 +171,108 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.10.____cpython</td>
+              <td>osx_64_microarch_level1numpy1.22python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1numpy1.22python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.8.____cpython</td>
+              <td>osx_64_microarch_level1numpy1.22python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1numpy1.22python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.9.____cpython</td>
+              <td>osx_64_microarch_level1numpy1.22python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1numpy1.22python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.23python3.11.____cpython</td>
+              <td>osx_64_microarch_level1numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.26python3.12.____cpython</td>
+              <td>osx_64_microarch_level1numpy1.26python3.12.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level1numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3numpy1.22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3numpy1.22python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3numpy1.22python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level3numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level3numpy1.26python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4numpy1.22python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4numpy1.22python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4numpy1.22python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4numpy1.22python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4numpy1.22python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4numpy1.22python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4numpy1.23python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_microarch_level4numpy1.26python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7559&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/graph-tool-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_microarch_level4numpy1.26python3.12.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -39,6 +39,15 @@ if [[ $target_platform == osx* ]]; then
     export CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
+if [[ "${microarch_level}" == "4" ]]; then
+    CXXFLAGS="${CXXFLAGS} -march=x86-64-v4"
+fi
+
+CPPFLAGS=$(echo "${CPPFLAGS}" | sed "s/-O2/-O3/g")
+CFLAGS=$(echo "${CFLAGS}" | sed "s/-O2/-O3/g")
+CXXFLAGS=$(echo "${CXXFLAGS}" | sed "s/-O2/-O3/g")
+LDFLAGS=$(echo "${LDFLAGS}" | sed "s/-O2/-O3/g")
+
 ./autogen.sh
 
 # Get an updated config.sub and config.guess

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+microarch_level:
+  - 1
+  - 3  # [unix and x86_64]
+  - 4  # [unix and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set version = "2.68" %}
 {% set sha1 = "79fab467ffb902e98fe7dea689e0274e9f33b18b" %}
+{% set build = 1001 %}
 
 package:
   name: graph-tool-suite
@@ -20,11 +21,15 @@ source:
 
     # When cross-compiling, don't let configure run a CGAL test program.
     # Just trust the location we pass via --with-cgal
-    - patches/skip-cgal-check.patch  # [build_platform != target_platform]
+    #- patches/skip-cgal-check.patch  # [build_platform != target_platform]
+    - patches/skip-cgal-check.patch
 
 build:
   skip: true  # [win]
-  number: 1000
+  number: {{ build }}          # [not (unix and x86_64)]
+  number: {{ build + 100 }}    # [unix and x86_64 and microarch_level == 1]
+  number: {{ build + 300 }}    # [unix and x86_64 and microarch_level == 3]
+  number: {{ build + 400 }}    # [unix and x86_64 and microarch_level == 4]
   detect_binary_files_with_prefix: true
 
   # conda-build 3.18.12 uses LIEF instead of patchelf,
@@ -62,6 +67,7 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ stdlib("c") }}
         - llvm-openmp           # [osx]
+        - x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level < 4]
       host:
         - python
         - setuptools
@@ -85,14 +91,15 @@ outputs:
         - gmp
         - sparsehash >=2.0
         - zstandard
+        - _x86_64-microarch-level {{ microarch_level }}  # [unix and x86_64 and microarch_level == 4]
 
     test:
       files:
-        - test_base_deps.sh
-        - test_base_imports.py
+        - test_base_deps.sh            # [microarch_level < 4]
+        - test_base_imports.py         # [microarch_level < 4]
       commands:
-        - bash test_base_deps.sh
-        - python test_base_imports.py
+        - bash test_base_deps.sh       # [microarch_level < 4]
+        - python test_base_imports.py  # [microarch_level < 4]
 
   - name: graph-tool
     requirements:
@@ -116,9 +123,9 @@ outputs:
         - matplotlib-base
     test:
       files:
-        - test_all_imports.py
+        - test_all_imports.py         # [microarch_level < 4]
       commands:
-        - python test_all_imports.py
+        - python test_all_imports.py  # [microarch_level < 4]
 
 about:
   home: https://graph-tool.skewed.de/

--- a/recipe/patches/skip-cgal-check.patch
+++ b/recipe/patches/skip-cgal-check.patch
@@ -10,7 +10,7 @@ index f3f3192e..c8779c76 100644
 +
 +                    dnl Third option here is the cross-compiling case
 +                    dnl https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Runtime.html
-+                    ,[ac_cgal=yes],[ac_cgal=no],[ac_cgal=yes])
++                    ,[ac_cgal=yes],[ac_cgal=yes],[ac_cgal=yes])
  
             LDFLAGS="$LDFLAGS_SAVED"
             export LDFLAGS


### PR DESCRIPTION
This brings our recent microarch updates (#140) into the `boost-1.82` branch.

**Note:** This branch uses build numbers starting at 1000.  The packages from this PR will have build numbers 1001, 1101, 1301, 1401.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy`

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
